### PR TITLE
投稿作成・編集フォームにエラーメッセージ表示

### DIFF
--- a/app/views/posts/_form.html.erb
+++ b/app/views/posts/_form.html.erb
@@ -1,4 +1,6 @@
 <%= form_with model: @post, class: "space-y-6", html: { multipart: true } do |f| %>
+  <%= render "shared/error_messages", object: @post %>
+
   <div>
     <%= f.label :title, class: "label font-medium" %>
     <%= f.text_field :title, class: "input input-bordered w-full", placeholder: t('helpers.placeholder.title') %>

--- a/app/views/shared/_error_messages.html.erb
+++ b/app/views/shared/_error_messages.html.erb
@@ -1,0 +1,9 @@
+<% if object.errors.any? %>
+  <div id="error_explanation" class="alert alert-danger">
+    <ul class="mb-0">
+      <% object.errors.each do |error| %>
+        <li><%= error.full_message %></li>
+      <% end %>
+    </ul>
+  </div>
+<% end %>

--- a/config/locales/activerecord/ja.yml
+++ b/config/locales/activerecord/ja.yml
@@ -14,6 +14,7 @@ ja:
         title: タイトル
         prefecture_id: 都道府県名
         category_id: カテゴリー
+        category: カテゴリー
         address: 住所
         description: コメント
         image: 画像


### PR DESCRIPTION
## 概要
投稿ページにおいて項目未入力で投稿できなかった際に
どの項目が必須か分かるようにエラーメッセージを表示した。