### PR TITLE
ユーザー登録フォームに地元歴を追加

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -5,6 +5,6 @@ class ApplicationController < ActionController::Base
 
   def configure_permitted_parameters
     devise_parameter_sanitizer.permit(:sign_up, keys: [ :name, :email, :prefecture_id, :local_history, :icon_image ])
-    devise_parameter_sanitizer.permit(:sign_in, keys: [ :email ])
+    devise_parameter_sanitizer.permit(:sign_in, keys: [ :email, :local_history ])
   end
 end

--- a/app/views/devise/registrations/new.html.erb
+++ b/app/views/devise/registrations/new.html.erb
@@ -22,6 +22,11 @@
           </div>
 
           <div>
+            <%= f.label :local_history, class: "label" %>
+            <%= f.text_field :local_history, class: "input input-bordered w-full", placeholder: t('helpers.placeholder.local_history') %>
+          </div>
+
+          <div>
             <%= f.label :email, class: "label" %>
             <%= f.email_field :email, class: "input input-bordered w-full", placeholder: t('helpers.placeholder.email') %>
           </div>

--- a/config/locales/activerecord/ja.yml
+++ b/config/locales/activerecord/ja.yml
@@ -9,6 +9,7 @@ ja:
       user:
         name: ユーザー名
         prefecture_id: 出身都道府県名
+        local_history: 地元歴
         email: メールアドレス
         password: パスワード
         password_confirmation: パスワード確認

--- a/config/locales/views/ja.yml
+++ b/config/locales/views/ja.yml
@@ -22,6 +22,7 @@ ja:
       name: ユーザー名を入力
       select_prefecture: 都道府県を選択
       select_category: カテゴリーを選択
+      local_history: 地元歴を入力
       email: メールアドレスを入力
       password: パスワードを入力
       password_confirmation: もう一度パスワードを入力


### PR DESCRIPTION
## 概要
ユーザー登録フォームに地元歴項目を追加しました。
- カラムは事前に登録済み
- 手動での入力
- ユーザー情報の編集機能は未実装