### PR TITLE
マイページ表示・編集機能実装

### DIFF
--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -1,0 +1,4 @@
+class UsersController < ApplicationController
+  def show
+  end
+end

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -1,4 +1,5 @@
 class UsersController < ApplicationController
   def show
+    @user = User.find(params[:id])
   end
 end

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -1,5 +1,37 @@
 class UsersController < ApplicationController
+  before_action :authenticate_user!, only: [:mypage, :edit, :update]
+  before_action :set_user, only: [:show, :edit, :update]
+
   def show
-    @user = User.find(params[:id])
+    @user ||= current_user
+  end
+
+  def edit
+    unless @user == current_user
+      redirect_to user_path(@user)
+    end
+  end
+
+  def update
+    if current_user.update(user_params)
+      redirect_to user_path(current_user), success: t("defaults.flash_message.updated", item: User.model_name.human)
+    else
+      flash.now[:danger] = t("defaults.flash_message.not_updated", item: User.model_name.human)
+      render :edit, status: :unprocessable_entity
+    end
+  end
+
+  def mypage
+    redirect_to user_path(current_user)
+  end
+
+  private
+
+  def set_user
+    @user = User.find(params[:id]) if params[:id].present?
+  end
+
+  def user_params
+    params.require(:user).permit(:name, :local_history, icon_image)
   end
 end

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -1,6 +1,6 @@
 class UsersController < ApplicationController
-  before_action :authenticate_user!, only: [:mypage, :edit, :update]
-  before_action :set_user, only: [:show, :edit, :update]
+  before_action :authenticate_user!, only: [ :mypage, :edit, :update ]
+  before_action :set_user, only: [ :show, :edit, :update ]
 
   def show
     @user = current_user

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -3,7 +3,7 @@ class UsersController < ApplicationController
   before_action :set_user, only: [:show, :edit, :update]
 
   def show
-    @user ||= current_user
+    @user = current_user
   end
 
   def edit
@@ -13,7 +13,7 @@ class UsersController < ApplicationController
   end
 
   def update
-    if current_user.update(user_params)
+    if @user.update(user_params)
       redirect_to user_path(current_user), success: t("defaults.flash_message.updated", item: User.model_name.human)
     else
       flash.now[:danger] = t("defaults.flash_message.not_updated", item: User.model_name.human)
@@ -28,10 +28,10 @@ class UsersController < ApplicationController
   private
 
   def set_user
-    @user = User.find(params[:id]) if params[:id].present?
+    @user = User.find(current_user.id)
   end
 
   def user_params
-    params.require(:user).permit(:name, :local_history, icon_image)
+    params.require(:user).permit(:name, :local_history, :icon_image, :icon_image_cache)
   end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -16,7 +16,7 @@ class User < ApplicationRecord
   has_many :comments, dependent: :destroy
 
   mount_uploader :icon_image, IconImageUploader
-  
+
   def like(post)
     like_posts << post
   end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -15,6 +15,8 @@ class User < ApplicationRecord
   has_many :like_posts, through: :likes, source: :post
   has_many :comments, dependent: :destroy
 
+  mount_uploader :icon_image, IconImageUploader
+  
   def like(post)
     like_posts << post
   end

--- a/app/uploaders/icon_image_uploader.rb
+++ b/app/uploaders/icon_image_uploader.rb
@@ -1,0 +1,47 @@
+class IconImageUploader < CarrierWave::Uploader::Base
+  # Include RMagick or MiniMagick support:
+  # include CarrierWave::RMagick
+  # include CarrierWave::MiniMagick
+
+  # Choose what kind of storage to use for this uploader:
+  storage :file
+  # storage :fog
+
+  # Override the directory where uploaded files will be stored.
+  # This is a sensible default for uploaders that are meant to be mounted:
+  def store_dir
+    "uploads/#{model.class.to_s.underscore}/#{mounted_as}/#{model.id}"
+  end
+
+  # Provide a default URL as a default if there hasn't been a file uploaded:
+  # def default_url(*args)
+  #   # For Rails 3.1+ asset pipeline compatibility:
+  #   # ActionController::Base.helpers.asset_path("fallback/" + [version_name, "default.png"].compact.join('_'))
+  #
+  #   "/images/fallback/" + [version_name, "default.png"].compact.join('_')
+  # end
+
+  # Process files as they are uploaded:
+  # process scale: [200, 300]
+  #
+  # def scale(width, height)
+  #   # do something
+  # end
+
+  # Create different versions of your uploaded files:
+  # version :thumb do
+  #   process resize_to_fit: [50, 50]
+  # end
+
+  # Add an allowlist of extensions which are allowed to be uploaded.
+  # For images you might use something like this:
+  # def extension_allowlist
+  #   %w(jpg jpeg gif png)
+  # end
+
+  # Override the filename of the uploaded files:
+  # Avoid using model.id or version_name here, see uploader/store.rb for details.
+  # def filename
+  #   "something.jpg" if original_filename
+  # end
+end

--- a/app/uploaders/icon_image_uploader.rb
+++ b/app/uploaders/icon_image_uploader.rb
@@ -14,7 +14,9 @@ class IconImageUploader < CarrierWave::Uploader::Base
   end
 
   # Provide a default URL as a default if there hasn't been a file uploaded:
-  # def default_url(*args)
+  def default_url
+    "noimage.png"
+  end
   #   # For Rails 3.1+ asset pipeline compatibility:
   #   # ActionController::Base.helpers.asset_path("fallback/" + [version_name, "default.png"].compact.join('_'))
   #
@@ -35,9 +37,9 @@ class IconImageUploader < CarrierWave::Uploader::Base
 
   # Add an allowlist of extensions which are allowed to be uploaded.
   # For images you might use something like this:
-  # def extension_allowlist
-  #   %w(jpg jpeg gif png)
-  # end
+  def extension_allowlist
+    %w[jpg jpeg gif png]
+  end
 
   # Override the filename of the uploaded files:
   # Avoid using model.id or version_name here, see uploader/store.rb for details.

--- a/app/uploaders/icon_image_uploader.rb
+++ b/app/uploaders/icon_image_uploader.rb
@@ -15,7 +15,7 @@ class IconImageUploader < CarrierWave::Uploader::Base
 
   # Provide a default URL as a default if there hasn't been a file uploaded:
   def default_url
-    "noimage.png"
+    "map.japan.png"
   end
   #   # For Rails 3.1+ asset pipeline compatibility:
   #   # ActionController::Base.helpers.asset_path("fallback/" + [version_name, "default.png"].compact.join('_'))

--- a/app/views/users/edit.html.erb
+++ b/app/views/users/edit.html.erb
@@ -1,7 +1,7 @@
 <main class="max-w-2xl mx-auto mt-12 p-8 bg-base-100 shadow-xl rounded-2xl border border-base-300">
   <h1 class="text-3xl font-bold text-center text-primary mb-8">プロフィール編集</h1>
 
-  <%= form_with model: @user, local: true do |f| %>
+  <%= form_with model: @user, url: user_path, local: true, html: { multipart: true } do |f| %>
     <div class="form-control mb-6">
       <label class="label">
         <span class="label-text font-semibold">名前</span>
@@ -13,21 +13,13 @@
       <label class="label">
         <span class="label-text font-semibold">地元歴</span>
       </label>
-      <%= f.text_field :local_history, class: "input input-bordered w-full", placeholder: "例：大阪10年・東京3年" %>
+      <%= f.text_field :local_history, class: "input input-bordered w-full", placeholder: "地元歴を入力" %>
     </div>
 
     <div class="form-control mb-6">
-      <label class="label">
-        <span class="label-text font-semibold">プロフィール画像</span>
-      </label>
-      <% if @user.icon_image.attached? %>
-        <div class="avatar mb-4">
-          <div class="w-24 rounded-full ring ring-primary ring-offset-base-100 ring-offset-2">
-            <%= image_tag @user.icon_image, alt: @user.name, class: "rounded-full" %>
-          </div>
-        </div>
-      <% end %>
-      <%= f.file_field :avatar, class: "file-input file-input-bordered w-full" %>
+      <%= f.label :icon_image, class: "label font-medium" %>
+      <%= f.file_field :icon_image, class: "file-input file-input-bordered w-full", accept: "image/*" %>
+      <%= f.hidden_field :icon_image_cache %>
     </div>
 
     <div class="flex justify-center gap-4 mt-8">

--- a/app/views/users/edit.html.erb
+++ b/app/views/users/edit.html.erb
@@ -1,0 +1,38 @@
+<main class="max-w-2xl mx-auto mt-12 p-8 bg-base-100 shadow-xl rounded-2xl border border-base-300">
+  <h1 class="text-3xl font-bold text-center text-primary mb-8">プロフィール編集</h1>
+
+  <%= form_with model: @user, local: true do |f| %>
+    <div class="form-control mb-6">
+      <label class="label">
+        <span class="label-text font-semibold">名前</span>
+      </label>
+      <%= f.text_field :name, class: "input input-bordered w-full", placeholder: "表示名を入力" %>
+    </div>
+
+    <div class="form-control mb-6">
+      <label class="label">
+        <span class="label-text font-semibold">地元歴</span>
+      </label>
+      <%= f.text_field :local_history, class: "input input-bordered w-full", placeholder: "例：大阪10年・東京3年" %>
+    </div>
+
+    <div class="form-control mb-6">
+      <label class="label">
+        <span class="label-text font-semibold">プロフィール画像</span>
+      </label>
+      <% if @user.icon_image.attached? %>
+        <div class="avatar mb-4">
+          <div class="w-24 rounded-full ring ring-primary ring-offset-base-100 ring-offset-2">
+            <%= image_tag @user.icon_image, alt: @user.name, class: "rounded-full" %>
+          </div>
+        </div>
+      <% end %>
+      <%= f.file_field :avatar, class: "file-input file-input-bordered w-full" %>
+    </div>
+
+    <div class="flex justify-center gap-4 mt-8">
+      <%= f.submit "更新する", class: "btn btn-primary btn-wide" %>
+      <%= link_to "キャンセル", user_path(@user), class: "btn btn-outline btn-wide" %>
+    </div>
+  <% end %>
+</main>

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -1,0 +1,4 @@
+<div>
+  <h1 class="font-bold text-4xl">Users#show</h1>
+  <p>Find me in app/views/users/show.html.erb</p>
+</div>

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -8,7 +8,7 @@
   <div class="flex flex-col items-center gap-4">
     <div class="avatar">
       <div class="w-32 rounded-full ring ring-primary ring-offset-base-100 ring-offset-2">
-        <%= image_tag @user.icon_image.presence || "local.image.jpeg", alt: @user.name, class: "rounded-full" %>
+        <%= image_tag @user.icon_image.url, class: "rounded-full" %>
       </div>
     </div>
 

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -1,4 +1,57 @@
-<div>
-  <h1 class="font-bold text-4xl">Users#show</h1>
-  <p>Find me in app/views/users/show.html.erb</p>
-</div>
+<main class="max-w-3xl mx-auto mt-12 p-6 bg-base-100 shadow-xl rounded-2xl border border-base-300">
+  <% if user_signed_in? && @user == current_user %>
+    <h1 class="text-3xl font-bold text-center text-primary mb-6">マイページ</h1>
+  <% else %>
+    <h1 class="text-3xl font-bold text-center text-secondary mb-6">ユーザーページ</h1>
+  <% end %>
+
+  <div class="flex flex-col items-center gap-4">
+    <div class="avatar">
+      <div class="w-32 rounded-full ring ring-primary ring-offset-base-100 ring-offset-2">
+        <%= image_tag @user.icon_image.presence || "local.image.jpeg", alt: @user.name, class: "rounded-full" %>
+      </div>
+    </div>
+
+    <div class="text-center">
+      <h2 class="text-xl font-semibold mb-2"><%= @user.name %></h2>
+      <p class="text-sm text-gray-500 mb-2">
+        出身地：
+        <span class="font-medium text-base-content">
+          <%= @user.prefecture.name %>
+        </span>
+        
+        地元歴：
+        <span class="font-medium text-base-content">
+          <%= @user.local_history.presence || "未登録" %>
+        </span>
+      </p>
+    </div>
+  </div>
+
+  <% if user_signed_in? && @user == current_user %>
+    <div class="text-center mt-6">
+      <%= link_to "プロフィールを編集する", edit_user_path(current_user),
+          class: "btn btn-primary btn-wide" %>
+    </div>
+  <% end %>
+
+  <div class="divider my-8"></div>
+
+  <div class="mt-4">
+    <h3 class="text-lg font-bold mb-4">投稿一覧</h3>
+    <% if @user.posts.any? %>
+      <div class="grid grid-cols-1 gap-4">
+        <% @user.posts.each do |post| %>
+          <div class="card bg-base-200 shadow-md hover:shadow-lg transition">
+            <div class="card-body">
+              <h4 class="card-title"><%= link_to post.title, post_path(post) %></h4>
+              <p class="text-sm text-gray-600"><%= truncate(post.description, length: 100) %></p>
+            </div>
+          </div>
+        <% end %>
+      </div>
+    <% else %>
+      <p class="text-center text-gray-400">まだ投稿がありません。</p>
+    <% end %>
+  </div>
+</main>

--- a/config/locales/activerecord/ja.yml
+++ b/config/locales/activerecord/ja.yml
@@ -11,6 +11,7 @@ ja:
         prefecture_id: 出身都道府県名
         local_history: 地元歴
         email: メールアドレス
+        icon_image: アイコン
         password: パスワード
         password_confirmation: パスワード確認
       post:

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -15,4 +15,7 @@ Rails.application.routes.draw do
       get :autocomplete
     end
   end
+
+  resources :users, only: [:show]
+  
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -16,6 +16,7 @@ Rails.application.routes.draw do
     end
   end
 
-  resources :users, only: [:show]
-  
+  resources :users, only: %i[show edit update]
+
+  get "mypage", to: "users#show", as: :mypage
 end


### PR DESCRIPTION
## 概要
マイページの表示・編集機能を実装しました。
- デフォルトアイコンをjapan.map.pngに設定
- 投稿一覧を設置

以下が未実装の物（別ブランチ予定）です。
- ヘッダーにマイページへの遷移を設置
- 投稿一覧、投稿詳細、コメントの名前を押すとマイページに遷移させる
- いいね一覧の設置
- プロフィール機能（他者）の実装